### PR TITLE
Add pprof to this project with localhost restriction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 WORKDIR /app
 COPY --from=upx /upx/pollendata /app/
 
-ENTRYPOINT ["/app/pollendata"]
+EXPOSE 6060
 
+ENTRYPOINT ["/app/pollendata"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 WORKDIR /app
 COPY --from=upx /upx/pollendata /app/
 
+EXPOSE 8080
 EXPOSE 6060
 
 ENTRYPOINT ["/app/pollendata"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,5 @@ WORKDIR /app
 COPY --from=upx /upx/pollendata /app/
 
 EXPOSE 8080
-EXPOSE 6060
 
 ENTRYPOINT ["/app/pollendata"]

--- a/source/cache.go
+++ b/source/cache.go
@@ -13,6 +13,7 @@ func updateCache() {
 	log.Println("Starting cache update loop...")
 	for {
 		if time.Since(lastUpdated) < 60*time.Minute {
+			time.Sleep(1 * time.Second)
 			continue
 		}
 


### PR DESCRIPTION
Add pprof to the project and restrict access to localhost.

* Import the `net/http/pprof` package in `source/main.go`.
* Add pprof routes under the `/debug/pprof/` path in `source/main.go`.
* Restrict access to pprof routes to localhost by adding a middleware in `source/main.go`.
* Expose port 6060 for pprof in the `Dockerfile`.

